### PR TITLE
Fix getting not yet processed demes

### DIFF
--- a/R/ga_metaepoch.R
+++ b/R/ga_metaepoch.R
@@ -8,10 +8,10 @@
 #' @examples
 ga_metaepoch <- function(config_ga) {
   function(fitness, suggestions, lower, upper, tree_level) {
-    config <- config_ga[tree_level]
+    config <- config_ga[[tree_level]]
     legal_passed_param_names <- Filter(function(name) {
       name %in% methods::formalArgs(GA::ga)
-    }, config)
+    }, names(config))
     params <- list("maxiter" = 5, "popSize" = nrow(suggestions))
     for (param_name in legal_passed_param_names) {
       params[param_name] <- config[param_name]

--- a/R/hms.R
+++ b/R/hms.R
@@ -235,5 +235,5 @@ get_not_yet_processed_demes <- function(all_demes, already_processed_demes) {
     }
     FALSE
   }
-  Filter(function(deme) { is_processed(deme) }, all_demes)
+  Filter(function(deme) { !is_processed(deme) }, all_demes)
 }

--- a/R/hms_class.R
+++ b/R/hms_class.R
@@ -59,7 +59,7 @@ print_tree <- function(demes, root_id, best_solution, show_details = TRUE) {
     }
     cat(paste(deme_distinguisher, "f", sep = ""))
     cat(get_solution_string(deme@best_solution))
-    active <- ifelse(deme@isActive, " A", "")
+    active <- ifelse(deme@is_active, " A", "")
     new_deme <- ifelse(length(deme@best_fitnesses_per_metaepoch) <= 1 & show_details & !is_root, " (new_deme)", "")
     cat(paste(" = ", sprintf(deme@best_fitness, fmt = "%#.2f"), deme_distinguisher, sep = ""))
     if (show_details) {
@@ -162,7 +162,7 @@ setMethod("plotActiveDemes", "hms", function(object) {
   metaepochs <- 1:object@metaepochs_count
   active_demes_per_metaepoch <- mapply(function(snapshot) {
     Filter(function(deme) {
-      deme@isActive
+      deme@is_active
     }, snapshot@demes)
   }, object@metaepoch_snapshots)
   active_demes_count_per_metaepoch <- mapply(length, active_demes_per_metaepoch)


### PR DESCRIPTION
Skrypt do porównywania naszej mutacji z tą defaultową dla GA:
```R
hms_root_mutation_comparison <- function(dimensions) {
  seeds <- 1:20

  fitness <- function(x) { -1 * Griewank(x) }
  lower <- rep(-600, dimensions)
  upper <- rep(600, dimensions)
  sigma <- list(rep(300, dimensions), rep(150, dimensions), rep(70, dimensions))

  run_hms <- function(with_ga_root_mutation, seed) {
    print(match.call())
    ga_config <- list(
      list(
        pmutation = 0.4
      ),
      list(
        pmutation = 0.2,
        mutation = rtnorm_mutation(lower, upper, sigma[[2]])
      ),
      list(
        pmutation = 0.2,
        mutation = rtnorm_mutation(lower, upper, sigma[[3]])
      )
    )
    norm_ga_config <- list(
      list(
        pmutation = 0.4,
        mutation = rtnorm_mutation(lower, upper, sigma[[1]])
      ),
      list(
        pmutation = 0.2,
        mutation = rtnorm_mutation(lower, upper, sigma[[2]])
      ),
      list(
        pmutation = 0.2,
        mutation = rtnorm_mutation(lower, upper, sigma[[3]])
      )
    )

    set.seed(seed)

    result <- hms(
      fitness = fitness,
      tree_height = 3,
      lower = lower,
      upper = upper,
      run_metaepoch = ga_metaepoch(if(with_ga_root_mutation) ga_config else norm_ga_config),
      population_size_per_tree_level = c(50, 30, 15),
      sigma = sigma,
      global_stopping_condition =   global_stopping_condition_max_fitness_evaluations(50000),
      sprouting_condition = max_metric_sprouting_condition(euclidean_distance, c(70, 50, 30)),
      local_stopping_condition = local_stopping_condition_metaepochs_without_improvement(10),
      monitor_level = "none"
    )
    print(result@best_fitness)
    result@best_fitness
  }

  norm_mutation <- mean(mapply(function(seed) { run_hms(FALSE, seed) }, seeds))
  ga_mutation <- mean(mapply(function(seed) { run_hms(TRUE, seed) }, seeds))


  cat("norm:", norm_mutation, "\n")
  cat("ga:", ga_mutation, "\n")
}
```
daje wyniki na naszą korzyść:
```
norm: -0.1797891 
ga: -0.2242517 
```
...tyle, że za kazdym razem kończy się z powodu braku aktywnych deme'ów